### PR TITLE
Explicit count modifiers for regex

### DIFF
--- a/Syntaxes/D.tmLanguage
+++ b/Syntaxes/D.tmLanguage
@@ -707,7 +707,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\\(\\|[abefnprtv'"?]|[0-3]\d{,2}|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8}|&amp;\w+;)</string>
+					<string>\\(\\|[abefnprtv'"?]|[0-3]\d{0,2}|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8}|&amp;\w+;)</string>
 					<key>name</key>
 					<string>constant.character.escape.d</string>
 				</dict>


### PR DESCRIPTION
The construction `{,2}` in regular expressions is only supported by Onigurma (which is used by TextMate). This TextMate bundle is used to highlight D code on GitHub. However, GitHub is using a [PCRE-based engine](https://github.com/vmg/pcre) for regexes and thus, the following code gets incorrectly highlighted.

``` d
const MAPI_LOGON_UI = \00;
```

This pull request fixes that by using an explicit count modifier in the regex.
