### PR TITLE
Fix syntax highlighting for "if" inside regular symbols

### DIFF
--- a/Syntaxes/D.tmLanguage
+++ b/Syntaxes/D.tmLanguage
@@ -194,7 +194,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>\s*(\b(else|switch)\b|((static)\s+)?(if))</string>
+			<string>\s*\b((else|switch)|((static)\s+)?(if))\b</string>
 			<key>name</key>
 			<string>meta.control.conditional.d</string>
 		</dict>

--- a/Tests/test.d
+++ b/Tests/test.d
@@ -41,12 +41,12 @@ void main() {
 	debug {
     Stdout("this is from within debug { }").newline;
   }
-  
+
   foreach_reverse(i,c; name) {
     Stdout.format("{}:{}, ", i, c);
   }
   Stdout.newline;
-  
+
   auto mc = new MyClass(14);
   mc.run();
 }

--- a/Tests/test.d
+++ b/Tests/test.d
@@ -50,3 +50,31 @@ void main() {
   auto mc = new MyClass(14);
   mc.run();
 }
+
+// "if" in "uniform" should not be parsed as keyword.control.conditional.d
+import std.random : Random, unpredictableSeed, uniform;
+
+// "static" and "if" should be parsed as keyword.control.conditional.d
+// "static" and "if be parsed as two separate words
+static if (true) {}
+
+void main()
+{
+    // "if" should be parsed as keyword.control.conditional.d
+    if (true) {}
+
+// "else" and "if" should be parsed as keyword.control.conditional.d
+// "else" and "if" should be parsed as two separate words
+else if (true) {}
+
+// "else" and "if" should be parsed as keyword.control.conditional.d
+// "else" and "if" should be parsed as two separate words
+else
+    if (true) {}
+
+    // "else" should be parsed as keyword.control.conditional.d
+    else{}
+
+// "if" should be parsed as keyword.control.conditional.d
+if (false) {}
+}


### PR DESCRIPTION
Currently `if` inside `uniform` is highlighted as a keyword:

```d
import std.random : Random, unpredictableSeed, uniform
```

For reference see https://github.com/textmate/d.tmbundle/commit/ccb8b6ba11def16841d22852cb6e942cbcdd8974#commitcomment-11704079

BTW, @infininight Do you know that this bundle is used by GitHub[1] for syntax highlighting via a Git submodule?

[1] https://github.com/github/linguist/tree/master/vendor/grammars