### PR TITLE
Correctly highlight variadic templates operator

### DIFF
--- a/Syntaxes/D.tmLanguage
+++ b/Syntaxes/D.tmLanguage
@@ -826,6 +826,12 @@
 		</dict>
 		<dict>
 			<key>match</key>
+			<string>(\.\.\.)</string>
+			<key>name</key>
+			<string>keyword.operator.variadic.d</string>
+		</dict>
+		<dict>
+			<key>match</key>
 			<string>(\.\.)</string>
 			<key>name</key>
 			<string>keyword.operator.slice.d</string>


### PR DESCRIPTION
Variadic templates operators (`auto something(T...)`) are not highlighted as they should (see [this issue](https://github.com/dlang-vscode/dlang-vscode/issues/40)).This PR simply adds a new scope for them.